### PR TITLE
"Logging on command" feature added

### DIFF
--- a/sopel_modules/chanlogs2/chanlogs2.py
+++ b/sopel_modules/chanlogs2/chanlogs2.py
@@ -153,7 +153,7 @@ def redirect_topic(bot, trigger):
     process_event(bot, trigger)
 
 
-@require_chanmsg('.logging_start is only permitted in channels')
+@require_chanmsg('.logging is only permitted in channels')
 @require_owner("Sorry, I can't do that for you")
 @module.commands("logging")
 @example('.logging (start|stop)')

--- a/sopel_modules/chanlogs2/chanlogs2.py
+++ b/sopel_modules/chanlogs2/chanlogs2.py
@@ -10,7 +10,6 @@ from contextlib import closing
 from sopel import module
 from sopel.tools import Identifier, SopelMemoryWithDefault
 from sopel.config.types import StaticSection, ValidatedAttribute, FilenameAttribute
-from sopel.module import require_chanmsg, require_owner, example
 import psycopg2
 from psycopg2.extras import Json
 
@@ -30,7 +29,7 @@ class Chanlogs2Section(StaticSection):
     # The following config options are only valid if the backend is 'file'
     logdir = FilenameAttribute('logdir', directory=True, default='~/chanlogs')
     by_day = ValidatedAttribute('by_day', parse=bool, default=True)
-    on_command = ValidatedAttribute('on_command', parse=bool, default=False)
+    allow_toggle = ValidatedAttribute('allow_toggle', parse=bool, default=False)
 
     privmsg_template = ValidatedAttribute('privmsg_template', default=None)
     action_template = ValidatedAttribute('action_template', default=None)
@@ -52,7 +51,7 @@ def configure(config):
         config.chanlogs2.configure_setting('pg_connection', 'PostgreSQL connection string, see http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING for more info')
     else:
         config.chanlogs2.configure_setting('logdir', 'Log storage directory')
-        config.chanlogs2.configure_setting('on_command', "Start and stop logging on the owner's command")
+        config.chanlogs2.configure_setting('allow_toggle', "Start and stop logging on an admin's command")
 
 
 def setup(bot):
@@ -153,19 +152,22 @@ def redirect_topic(bot, trigger):
     process_event(bot, trigger)
 
 
-@require_chanmsg('.logging is only permitted in channels')
-@require_owner("Sorry, I can't do that for you")
-@module.commands("logging")
-@example('.logging (start|stop)')
+@module.require_chanmsg('.log is only permitted in channels')
+@module.require_admin("Sorry, I can't do that for you")
+@module.commands("log")
+@module.example('.log start')
 def logging_command(bot, trigger):
-    if trigger.group(2) == 'start':
-        bot.db.set_channel_value(trigger.sender, 'log_channel', True)
-        bot.reply('Logging started')
-    elif trigger.group(2) == 'stop':
-        bot.db.set_channel_value(trigger.sender, 'log_channel', False)
-        bot.reply('Logging stopped')
+    if bot.config.chanlogs2.allow_toggle:
+        if trigger.group(2) == 'start':
+            bot.db.set_channel_value(trigger.sender, 'logging', True)
+            bot.reply('Logging started for this channel')
+        elif trigger.group(2) == 'stop':
+            bot.db.set_channel_value(trigger.sender, 'logging', False)
+            bot.reply('Logging stopped for this channel')
+        else:
+            bot.reply("Please, use '.log start' or '.log stop'")
     else:
-        bot.reply("Please, use '.logging start' or '.logging stop'")
+        bot.reply("I'm already logging everything.")
 
 
 def process_event(bot, trigger):
@@ -181,32 +183,20 @@ def process_event(bot, trigger):
 
 
 def write_log(bot, event, channel):
-    try:
-        log_channel = bot.db.get_channel_value(channel, 'log_channel')
-    except:
-        log_channel = False
-    if bot.config.chanlogs2.on_command and log_channel:  # Checks if the bot is set to log on command and if the channel has to be logged
-        if not isinstance(channel, Identifier):
-            channel = Identifier(channel)
+    if bot.config.chanlogs2.allow_toggle:
+        if not bot.db.get_channel_value(channel, 'logging'):
+            return
 
-        if channel.is_nick() and not bot.config.chanlogs2.privmsg:
-            return  # Don't log if we are configured not to log PMs
+    if not isinstance(channel, Identifier):
+        channel = Identifier(channel)
 
-        if bot.config.chanlogs2.backend == 'postgres':
-            write_db_line(bot, event, channel)
-        else:
-            write_log_line(bot, event, channel)
-    elif not bot.config.chanlogs2.on_command:  # Logs everything if on_command is False
-        if not isinstance(channel, Identifier):
-            channel = Identifier(channel)
+    if channel.is_nick() and not bot.config.chanlogs2.privmsg:
+        return  # Don't log if we are configured not to log PMs
 
-        if channel.is_nick() and not bot.config.chanlogs2.privmsg:
-            return  # Don't log if we are configured not to log PMs
-
-        if bot.config.chanlogs2.backend == 'postgres':
-            write_db_line(bot, event, channel)
-        else:
-            write_log_line(bot, event, channel)
+    if bot.config.chanlogs2.backend == 'postgres':
+        write_db_line(bot, event, channel)
+    else:
+        write_log_line(bot, event, channel)
 
 
 def get_conn(bot):


### PR DESCRIPTION
As promised, added the complete "logging on command" feature.
Can be set to True or False in the [chanlogs2] section of the sopel config.
Is off by default, logging all channels.
When turned on, the bot will start logging once it receives a command '.logging start' from its owner, and will stop once it receives '.logging stop'. Only accepts this command via channel messages.
